### PR TITLE
Revert "add centos6 compatibility for package docker-io"

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,13 +8,6 @@
 #   Passed to the docker package.
 #   Defaults to present
 #
-# [*package_manage*]
-#   Whether to manage the docker package
-#   Defaults to true
-#
-# [*package_name*]
-#   Docker Package name
-#
 # [*service_state*]
 #   Whether you want to docker daemon to start up
 #   Defaults to running
@@ -137,8 +130,6 @@
 #
 class docker(
   $ensure                      = $docker::params::ensure,
-  $package_manage              = $docker::params::package_manage,
-  $package_name                = $docker::params::package_name,
   $service_state               = $docker::params::service_state,
   $service_enable              = $docker::params::service_enable,
   $service_state_storage       = $docker::params::service_state_storage,
@@ -147,7 +138,7 @@ class docker(
   $bind_to                     = $docker::params::bind_to,
   $log_level                   = $docker::params::log_level,
   $tmp_dir                     = $docker::params::tmp_dir,
-  $log_rotate                  = $docker::params::log_rotate,
+  $log_rotate		       = $docker::params::log_rotate,
   $dns                         = $docker::params::dns,
   $dns_search                  = $docker::params::dns_search,
   $add_registry                = $docker::params::add_registry,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,13 +5,5 @@
 # and Archlinux based distributions.
 #
 class docker::install {
-
-  if $docker::package_manage {
-
-    package { $docker::package_name:
-      ensure => $docker::ensure,
-    }
-
-  }
-
+  package { 'docker': ensure => $docker::ensure, }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,7 +4,6 @@
 #
 class docker::params {
   $ensure = 'present'
-  $package_manage = true
   $service_state = running
   $service_enable = true
   $service_state_storage = 'stopped'
@@ -37,22 +36,4 @@ class docker::params {
   $iptables = undef
   $ip_masq = undef
   $network_extra_parameters = undef
-
-  #set package to docker-io for centos6 specifically
-  case $::osfamily {
-    'RedHat': {
-      case $::operatingsystemmajrelease {
-        6: {
-          $package_name = 'docker-io'
-        }
-        7: {
-          $package_name = 'docker'
-        }
-      }
-    }
-    default: {
-      $package_name = 'docker'
-    }
-  }
-
 }


### PR DESCRIPTION
Reverts discodex/puppet-docker#1

Getting the following error, need to revert and re-review this:
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Missing title. The title expression resulted in undef at /etc/puppetlabs/code/environments/production/modules/docker/manifests/install.pp:10:15 on node n05.r2.minion.mwp.int.liquidweb.com